### PR TITLE
Update Actions for AVH-1.1.1

### DIFF
--- a/.github/workflows/virtual_hardware_sh.yml
+++ b/.github/workflows/virtual_hardware_sh.yml
@@ -25,7 +25,7 @@ jobs:
         run: echo "${{ github.repository }} has been cloned."
 
       - name: Build the micro_speech example
-        run: cbuild.sh microspeech.Example.cprj
+        run: cbuild.sh microspeech.Example.cprj --quiet
         working-directory: ${{env.working-directory}}
 
       - name: Run the micro_speech example

--- a/.github/workflows/virtual_hardware_sh.yml
+++ b/.github/workflows/virtual_hardware_sh.yml
@@ -24,10 +24,6 @@ jobs:
       - name: What has been cloned?
         run: echo "${{ github.repository }} has been cloned."
 
-      - name: Get dependencies
-        run: cp_install.sh packlist
-        working-directory: ${{env.working-directory}}
-
       - name: Build the micro_speech example
         run: cbuild.sh microspeech.Example.cprj
         working-directory: ${{env.working-directory}}


### PR DESCRIPTION
AVH 1.1.1 comes with CMSIS build 0.10.4 and cmake 3.22 which introduce some changes:
- cp_install.sh is not provided anymore as part of CMSIS build
- Policy CMP0123 warnings are displayed by cmake when building but can safely be ignored

