### PR TITLE
CI test workflow issue in the repo

### DIFF
--- a/.github/workflows/virtual_hardware_sh.yml
+++ b/.github/workflows/virtual_hardware_sh.yml
@@ -25,7 +25,7 @@ jobs:
         run: echo "${{ github.repository }} has been cloned."
 
       - name: Get dependencies
-        run: ./packlist.sh packlist
+        run: bash packlist.sh packlist
         working-directory: ${{env.working-directory}}
 
       - name: Build the micro_speech example

--- a/.github/workflows/virtual_hardware_sh.yml
+++ b/.github/workflows/virtual_hardware_sh.yml
@@ -25,7 +25,7 @@ jobs:
         run: echo "${{ github.repository }} has been cloned."
 
       - name: Get dependencies
-        run: cp_install.sh packlist
+        run: packlist.sh packlist
         working-directory: ${{env.working-directory}}
 
       - name: Build the micro_speech example

--- a/.github/workflows/virtual_hardware_sh.yml
+++ b/.github/workflows/virtual_hardware_sh.yml
@@ -25,7 +25,7 @@ jobs:
         run: echo "${{ github.repository }} has been cloned."
 
       - name: Get dependencies
-        run: packlist.sh packlist
+        run: ./packlist.sh packlist
         working-directory: ${{env.working-directory}}
 
       - name: Build the micro_speech example


### PR DESCRIPTION
cp_install.sh does't exist in cmsis-build 0.10.4 anymore so the cp_install.sh command is lost when you carry the CI test. It always failed. 