### PR TITLE
Replace IAM User creds with IAM Role

### DIFF
--- a/.github/workflows/virtual_hardware_gh.yml
+++ b/.github/workflows/virtual_hardware_gh.yml
@@ -1,19 +1,17 @@
 # This is a basic workflow to help you get started with Actions on CMSIS projects
 # See also https://community.arm.com/developer/tools-software/tools/b/tools-software-ides-blog/posts/infrastructure-for-continuous-integration-tests
 
-name: Arm Virtual Hardware example - github hosted - remote AWS via avhclient 
+name: Arm Virtual Hardware example - github hosted - remote AWS via avhclient
 
 on:
 #  push:
 #    branches: [ main ]
 #  pull_request:
 #    branches: [ main ]
-# To allow you to run this workflow manually 
+# To allow you to run this workflow manually
   workflow_dispatch:
 
 env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
   AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
   AWS_IAM_PROFILE: ${{ secrets.AWS_IAM_PROFILE }}
@@ -24,6 +22,9 @@ env:
 jobs:
   arm_virtual_hardware:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.10
@@ -33,12 +34,14 @@ jobs:
       - name: Install AVH Client for Python
         run: |
           pip install git+https://github.com/ARM-software/avhclient.git@v0.1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::720528183931:role/Proj-vht-assume-role
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Execute test suite on Arm Virtual Hardware at AWS
         run: |
           avhclient -b aws execute --specfile ./avh.yml
       - name: Fetch results from Arm Virtual Hardware
         run: |
            cat ./Platform_FVP_Corstone_SSE-300_Ethos-U55/microspeech.log
-
-
-


### PR DESCRIPTION
This avoids rotation of the IAM User creds.

The secrets `AWS_ACCESS_KEY_ID ` and `AWS_SECRET_ACCESS_KEY ` can be deleted after this PR is merged.